### PR TITLE
Fix parsing of empty Choice term, explicit term construction, support terms with title!=value, new tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.2.5 (unreleased)
 ------------------
 
+- Support Choice fields with terms containing distinct title from value
+  as option, while preserving backward-compatible round-trip for all
+  Choice fields where title is not distinct from value.
+  [seanupton]
+
 - Fix parsing of empty Choice term to u'', not None, which addresses a
   cause of https://github.com/plone/plone.app.dexterity/issues/49
   [seanupton]

--- a/plone/supermodel/fields.txt
+++ b/plone/supermodel/fields.txt
@@ -1321,6 +1321,34 @@ tokens are the utf8-encoded values).
     >>> [t.value for t in reciprocal.vocabulary]
     [u'a', u'\xe7']
 
+
+Additionally, it is possible for Choice fields with a values vocabulary
+whose terms contain values distinct from term titles for each
+respective term.  This is accomplished by using the 'key' attribute
+of each contained 'element' of the values element (this is consistent
+with how Dict fields are output, only for Choices, order is guaranteed).
+
+    >>> from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
+    >>> vocab = SimpleVocabulary([
+    ...     SimpleTerm(value=u'a', title=u'A'),
+    ...     SimpleTerm(value=u'b', title=u'B'),
+    ...     ])
+    >>> field = schema.Choice(
+    ...     __name__="dummy",
+    ...     title=u"Test",
+    ...     vocabulary=vocab,
+    ...     )
+    >>> handler = getUtility(IFieldExportImportHandler, name=fieldType)
+    >>> element = handler.write(field, 'dummy', fieldType)
+    >>> print prettyXML(element)
+    <field name="dummy" type="zope.schema.Choice">
+      <title>Test</title>
+      <values>
+        <element key="a">A</element>
+        <element key="b">B</element>
+      </values>
+    </field>
+
 3. Sources and source binders
 
 We cannot export choice fields with a source or context source binder:

--- a/plone/supermodel/utils.py
+++ b/plone/supermodel/utils.py
@@ -11,6 +11,12 @@ from zope.i18nmessageid import Message
 from plone.supermodel.interfaces import XML_NAMESPACE, I18N_NAMESPACE, IToUnicode
 from plone.supermodel.debug import parseinfo
 
+try:
+    from collections import OrderedDict
+except:
+    from zope.schema import OrderedDict  # <py27
+
+
 _marker = object()
 noNS_re = re.compile('^{\S+}')
 
@@ -87,7 +93,7 @@ def elementToValue(field, element, default=_marker):
 
     if IDict.providedBy(field):
         key_converter = IFromUnicode(field.key_type)
-        value = {}
+        value = OrderedDict()
         for child in element.iterchildren(tag=etree.Element):
             if noNS(child.tag.lower()) != 'element':
                 continue

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,12 @@
 import os
+import sys
 from setuptools import setup, find_packages
+
+
+# if <= Python 2.6 or less, specify minimum zope.schema compatible:
+ZOPESCHEMA = 'zope.schema'
+if sys.version_info < (2, 7):
+    ZOPESCHEMA += '>=4.1.0'
 
 
 def read(*rnames):
@@ -39,7 +46,7 @@ setup(name='plone.supermodel',
           'lxml',
           'zope.component',
           'zope.interface',
-          'zope.schema',
+          ZOPESCHEMA,
           'zope.deferredimport',
           'zope.dottedname',
           'z3c.zcmlhook',


### PR DESCRIPTION
See changelog.

This should, in theory, fix https://github.com/plone/plone.app.dexterity/issues/49

It also should enable folks who want to serialize and parse schemas containing Choice fields that have vocabulary terms with term.title != term.value.

Added numerous tests for ChoiceHandler (new) and additional doctest scenario for the new feature.
