### PR TITLE
Implement serialization support for i18n message

### DIFF
--- a/plone/supermodel/configure.zcml
+++ b/plone/supermodel/configure.zcml
@@ -143,6 +143,10 @@
         component=".fields.ChoiceHandler"
         name="zope.schema.Choice"
         />
+    <utility
+        component=".fields.MessageIdHandler"
+        name="zope.i18nmessageid"
+        />
 
     <!-- Field name extractors -->
     <adapter factory=".serializer.DefaultFieldNameExtractor" />

--- a/plone/supermodel/fields.py
+++ b/plone/supermodel/fields.py
@@ -28,3 +28,7 @@ DottedNameHandler = plone.supermodel.exportimport.BaseHandler(zope.schema.Dotted
 InterfaceFieldHandler = plone.supermodel.exportimport.BaseHandler(zope.schema.InterfaceField)
 ObjectHandler = plone.supermodel.exportimport.ObjectHandler(zope.schema.Object)
 ChoiceHandler = plone.supermodel.exportimport.ChoiceHandler(zope.schema.Choice)
+
+# Field metadata handlers
+
+MessageIdHandler = plone.supermodel.exportimport.MessageIdHandler()

--- a/plone/supermodel/parser.py
+++ b/plone/supermodel/parser.py
@@ -21,7 +21,6 @@ from plone.supermodel.utils import ns
 
 from plone.supermodel.model import Model, Fieldset, Schema, SchemaClass
 from plone.supermodel.interfaces import FIELDSETS_KEY
-from plone.supermodel.interfaces import I18N_NAMESPACE
 from plone.supermodel.debug import parseinfo
 
 
@@ -81,8 +80,6 @@ def parse(source, policy=u""):
 def _parse(source, policy):
     tree = etree.parse(source)
     root = tree.getroot()
-
-    parseinfo.i18n_domain = root.attrib.get(ns('domain', prefix=I18N_NAMESPACE))
 
     model = Model()
 

--- a/plone/supermodel/schema.txt
+++ b/plone/supermodel/schema.txt
@@ -107,7 +107,7 @@ In addition to parsing, we can serialize a model to an XML representation:
 
     >>> from plone.supermodel import serializeModel
     >>> print serializeModel(model) # doctest: +NORMALIZE_WHITESPACE
-    <model xmlns="http://namespaces.plone.org/supermodel/schema">
+    <model xmlns:i18n="http://xml.zope.org/namespaces/i18n" xmlns="http://namespaces.plone.org/supermodel/schema">
       <schema>
         <field name="title" type="zope.schema.TextLine">
           <title>Title</title>
@@ -195,7 +195,7 @@ of just a single schema using serializeSchema():
 
     >>> from plone.supermodel import serializeSchema
     >>> print serializeSchema(ITestContent) # doctest: +NORMALIZE_WHITESPACE
-    <model xmlns="http://namespaces.plone.org/supermodel/schema">
+    <model xmlns:i18n="http://xml.zope.org/namespaces/i18n" xmlns="http://namespaces.plone.org/supermodel/schema">
       <schema>
         <field name="title" type="zope.schema.TextLine">
           <title>Title</title>
@@ -208,7 +208,7 @@ of just a single schema using serializeSchema():
     </model>
 
     >>> print serializeSchema(ITestMetadata, name=u"metadata") # doctest: +NORMALIZE_WHITESPACE
-    <model xmlns="http://namespaces.plone.org/supermodel/schema">
+    <model xmlns:i18n="http://xml.zope.org/namespaces/i18n" xmlns="http://namespaces.plone.org/supermodel/schema">
       <schema name="metadata">
         <field name="created" type="zope.schema.Datetime">
           <required>False</required>
@@ -249,7 +249,7 @@ Then, let's define a schema that is based on this interface.
 
     >>> schema = """\
     ... <?xml version="1.0" encoding="UTF-8"?>
-    ... <model xmlns="http://namespaces.plone.org/supermodel/schema">
+    ... <model xmlns:i18n="http://xml.zope.org/namespaces/i18n" xmlns="http://namespaces.plone.org/supermodel/schema">
     ...     <schema based-on="plone.supermodel.tests.IBase">
     ...         <field type="zope.schema.Text" name="description">
     ...             <title>Description</title>
@@ -291,7 +291,7 @@ We should also verify that the description field was indeed overridden:
 Finally, let's verify that bases are preserved upon serialisation:
 
     >>> print serializeSchema(model.schema) # doctest: +NORMALIZE_WHITESPACE
-    <model xmlns="http://namespaces.plone.org/supermodel/schema">
+    <model xmlns:i18n="http://xml.zope.org/namespaces/i18n" xmlns="http://namespaces.plone.org/supermodel/schema">
       <schema based-on="plone.supermodel.tests.IBase">
         <field name="description" type="zope.schema.Text">
           <description>A short summary</description>
@@ -404,7 +404,7 @@ When we serialise a schema with fieldsets, fields will be grouped by
 fieldset.
 
     >>> print serializeModel(model) # doctest: +NORMALIZE_WHITESPACE
-    <model xmlns="http://namespaces.plone.org/supermodel/schema">
+    <model xmlns:i18n="http://xml.zope.org/namespaces/i18n" xmlns="http://namespaces.plone.org/supermodel/schema">
       <schema>
         <field name="title" type="zope.schema.TextLine">
           <title>Title</title>
@@ -483,7 +483,7 @@ in action.
 The model's serialization should include the invariant.
 
     >>> print serializeModel(model) # doctest: +NORMALIZE_WHITESPACE
-    <model xmlns="http://namespaces.plone.org/supermodel/schema">
+    <model xmlns:i18n="http://xml.zope.org/namespaces/i18n" xmlns="http://namespaces.plone.org/supermodel/schema">
       <schema>
         <invariant>plone.supermodel.tests.dummy_invariant</invariant>
         <invariant>plone.supermodel.tests.dummy_invariant_prime</invariant>
@@ -552,6 +552,14 @@ as a zope.i18nmessageid message id rather than a basic Unicode string::
     <type 'zope.i18nmessageid.message.Message'>
     >>> msgid.default
     u'Title'
+    >>> print serializeModel(model) # doctest: +NORMALIZE_WHITESPACE
+    <model xmlns:i18n="http://xml.zope.org/namespaces/i18n" xmlns="http://namespaces.plone.org/supermodel/schema" i18n:domain="plone.supermodel">
+      <schema>
+        <field name="title" type="zope.schema.TextLine">
+          <title i18n:translate="supermodel_test_title">Title</title>
+        </field>
+      </schema>
+    </model>
 
 Creating custom metadata handlers
 ---------------------------------
@@ -649,7 +657,7 @@ Of course, we can also serialize the schema back to XML. Here, the 'prefix'
 set in the utility (if any) will be used by default.
 
     >>> print serializeModel(model) # doctest: +NORMALIZE_WHITESPACE
-    <model xmlns:ui="http://namespaces.acme.com/ui" xmlns="http://namespaces.plone.org/supermodel/schema">
+    <model xmlns:i18n="http://xml.zope.org/namespaces/i18n" xmlns:ui="http://namespaces.acme.com/ui" xmlns="http://namespaces.plone.org/supermodel/schema">
       <schema ui:layout="horizontal">
         <field name="title" type="zope.schema.TextLine" ui:widget="largetype">
           <title>Title</title>

--- a/plone/supermodel/serializer.py
+++ b/plone/supermodel/serializer.py
@@ -10,12 +10,13 @@ from plone.supermodel.interfaces import ISchemaMetadataHandler
 from plone.supermodel.interfaces import IFieldMetadataHandler
 
 from plone.supermodel.interfaces import XML_NAMESPACE
+from plone.supermodel.interfaces import I18N_NAMESPACE
 from plone.supermodel.interfaces import FIELDSETS_KEY
 from plone.supermodel.interfaces import IFieldNameExtractor
 
 from plone.supermodel.model import Schema
 
-from plone.supermodel.utils import sortedFields, prettyXML
+from plone.supermodel.utils import ns, sortedFields, prettyXML
 from lxml import etree
 
 
@@ -120,6 +121,11 @@ def serialize(model):
 
         for handler_name, metadata_handler in schema_metadata_handlers:
             metadata_handler.write(schema_element, schema)
+
+        i18n_domain = schema_element.get(ns('domain', prefix=I18N_NAMESPACE))
+        if i18n_domain:
+            xml.set(ns('domain', prefix=I18N_NAMESPACE), i18n_domain)
+            schema_element.attrib.pop(ns('domain', prefix=I18N_NAMESPACE))
 
         xml.append(schema_element)
 

--- a/plone/supermodel/tests.py
+++ b/plone/supermodel/tests.py
@@ -19,8 +19,6 @@ from plone.supermodel.exportimport import ChoiceHandler
 from plone.supermodel.interfaces import IDefaultFactory
 from plone.supermodel.interfaces import IInvariant
 
-from zope.i18nmessageid import MessageFactory
-
 
 def configure():
     zope.component.testing.setUp()
@@ -352,14 +350,6 @@ class TestValueToElement(unittest.TestCase):
         self.assertEqual(sio.getvalue(), expected)
         unserialized = utils.elementToValue(field, element)
         self.assertEqual(value, unserialized)
-
-    def test_message(self):
-        _ = MessageFactory('my.domain')
-        field = schema.TextLine()
-        value = _('msgid', default=u'Default translation')
-        self._assertSerialized(
-            field, value,
-            '<value i18n:translate="msgid">Default translation</value>')
 
     def test_lists(self):
         field = schema.List(value_type=schema.Int())

--- a/plone/supermodel/utils.py
+++ b/plone/supermodel/utils.py
@@ -6,10 +6,10 @@ from lxml import etree
 
 from zope.interface import directlyProvidedBy, directlyProvides
 from zope.schema.interfaces import IField, IFromUnicode, IDict, ICollection
-from zope.i18nmessageid import Message
 
-from plone.supermodel.interfaces import XML_NAMESPACE, I18N_NAMESPACE, IToUnicode
+from plone.supermodel.interfaces import XML_NAMESPACE, IToUnicode
 from plone.supermodel.debug import parseinfo
+
 
 try:
     from collections import OrderedDict
@@ -129,15 +129,6 @@ def elementToValue(field, element, default=_marker):
             converter = IFromUnicode(field)
             value = converter.fromUnicode(unicode(text))
 
-        # handle i18n
-        if isinstance(value, unicode) and parseinfo.i18n_domain is not None:
-            translate_attr = ns('translate', I18N_NAMESPACE)
-            msgid = element.attrib.get(translate_attr)
-            if msgid:
-                value = Message(msgid, domain=parseinfo.i18n_domain, default=value)
-            elif translate_attr in element.attrib:
-                value = Message(value, domain=parseinfo.i18n_domain)
-
     return value
 
 
@@ -174,12 +165,6 @@ def valueToElement(field, value, name=None, force=False):
         else:
             converter = IToUnicode(field)
             child.text = converter.toUnicode(value)
-
-            # handle i18n
-            if isinstance(value, Message):
-                translate_attr = ns('translate', I18N_NAMESPACE)
-                child.attrib[translate_attr] = child.text
-                child.text = converter.toUnicode(value.default)
 
     return child
 


### PR DESCRIPTION
For discussion. Replaces previous i18n parser implementation so, do not merge yet.

See also: https://github.com/plone/plone.app.dexterity/issues/132

@davisagli 

I couldn't figure out a such nice way to implement i18n serialization support, which would have been similar to the current parser implementation, so I ended up implementing the support as a field metadata handler (plus a few lines to add the default domain into model root tag).

What do you think? Of course, I could also restore the original parser implementation so that these could coexist.
