### PR TITLE
support latest zope.i18nmessageid.message.Message

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Test-Fix: Support latest zope.i18nmessageid.
+  [jensens]
 
 
 1.3.0 (2016-06-07)

--- a/plone/supermodel/schema.rst
+++ b/plone/supermodel/schema.rst
@@ -558,7 +558,7 @@ as a zope.i18nmessageid message id rather than a basic Unicode string::
     >>> msgid
     u'supermodel_test_title'
     >>> type(msgid)
-    <type 'zope.i18nmessageid.message.Message'>
+    <... 'zope.i18nmessageid.message.Message'>
     >>> msgid.default
     u'Title'
     >>> print serializeModel(model) # doctest: +NORMALIZE_WHITESPACE


### PR DESCRIPTION
latest version of zope.i18nmessageid reports itself as a class not type: support both in test.