### PR TITLE
Fix issue where choice parser failed to parse vocabulary values with separate keys and display titles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix issue where supermodel XML choice field parser failed to parse vocabulary
+  values with separate keys and display titles, because the parser expected
+  values tag to not have any namespace.
+  [datakurre]
 
 
 1.3.1 (2016-12-30)

--- a/plone/supermodel/exportimport.py
+++ b/plone/supermodel/exportimport.py
@@ -332,7 +332,7 @@ class ChoiceHandler(BaseHandler):
 
     def readAttribute(self, element, attributeField):
         if (
-            element.tag == 'values' and
+            etree.QName(element).localname == 'values' and
             any([child.get('key') for child in element])
         ):
             attributeField = OrderedDictField(

--- a/plone/supermodel/tests.py
+++ b/plone/supermodel/tests.py
@@ -451,6 +451,22 @@ class TestChoiceHandling(unittest.TestCase):
             '</field>'
         return (schema.Choice(vocabulary=vocab), expected)
 
+    def _choice_with_term_titles_and_ns(self):
+        # two terms with distinct titles, one with same as value:
+        vocab = SimpleVocabulary(
+            [SimpleTerm(t, title=t.upper()) for t in (u'a', u'b')] +
+            [SimpleTerm(u'c', title=u'c')],
+            )
+        expected = '<field name="myfield" type="zope.schema.Choice"'\
+            '      xmlns="http://namespaces.plone.org/supermodel/schema">'\
+            '<values>'\
+            '<element key="a">A</element>'\
+            '<element key="b">B</element>'\
+            '<element key="c">c</element>'\
+            '</values>'\
+            '</field>'
+        return (schema.Choice(vocabulary=vocab), expected)
+
     def test_choice_serialized(self):
         field, expected = self._choice()
         el = self.handler.write(field, 'myfield', 'zope.schema.Choice')
@@ -471,6 +487,7 @@ class TestChoiceHandling(unittest.TestCase):
             self._choice(),
             self._choice_with_empty(),
             self._choice_with_term_titles(),
+            self._choice_with_term_titles_and_ns(),
         )
         for field, expected in cases:
             el = etree.fromstring(expected)


### PR DESCRIPTION
The included test should fail without the included patch.