### PR TITLE
ensure sets are serialized consistently

### DIFF
--- a/news/30.bugfix
+++ b/news/30.bugfix
@@ -1,0 +1,1 @@
+tests to ensure schema.Set is serialized consistently

--- a/plone/supermodel/tests.py
+++ b/plone/supermodel/tests.py
@@ -369,6 +369,34 @@ class TestValueToElement(unittest.TestCase):
             b'</value>'
         )
 
+    def test_sets(self):
+        field = schema.Set(value_type=schema.Int(),
+        )
+        value = set([])
+        self._assertSerialized(field, value, b'<value/>')
+        value = set([3, 4, 2, 1])
+        # Sets should be sorted to ensure nice diffs
+        self._assertSerialized(
+            field, value,
+            b'<value>'
+            b'<element>1</element>'
+            b'<element>2</element>'
+            b'<element>3</element>'
+            b'<element>4</element>'
+            b'</value>'
+        )
+
+        field = schema.Set(value_type=schema.Text(),)
+        value = set(['b', 'a'])
+        # Sets should be sorted to ensure nice diffs
+        self._assertSerialized(
+            field, value,
+            b'<value>'
+            b'<element>a</element>'
+            b'<element>b</element>'
+            b'</value>'
+        )
+
     def test_nested_lists(self):
         field = schema.List(value_type=schema.List(value_type=schema.Int()))
         value = []
@@ -411,6 +439,9 @@ class TestValueToElement(unittest.TestCase):
             b'<element key="6"/>'
             b'</value>'
         )
+
+
+
 
 
 class TestChoiceHandling(unittest.TestCase):

--- a/plone/supermodel/tests.py
+++ b/plone/supermodel/tests.py
@@ -386,7 +386,7 @@ class TestValueToElement(unittest.TestCase):
             b'</value>'
         )
 
-        field = schema.Set(value_type=schema.Text(),)
+        field = schema.Set(value_type=schema.Choice(['a','b','c']),)
         value = set(['b', 'a'])
         # Sets should be sorted to ensure nice diffs
         self._assertSerialized(

--- a/plone/supermodel/utils.py
+++ b/plone/supermodel/utils.py
@@ -13,6 +13,7 @@ from zope.schema.interfaces import ICollection
 from zope.schema.interfaces import IDict
 from zope.schema.interfaces import IField
 from zope.schema.interfaces import IFromUnicode
+from zope.schema.interfaces import ISet
 
 import os.path
 import re
@@ -203,6 +204,9 @@ def valueToElement(field, value, name=None, force=False):
                 child.append(list_element)
 
         elif ICollection.providedBy(field):
+            if ISet.providedBy(field):
+                # Serliazation should be consistent even if value was not really a set
+                value = sorted(value)
             for v in value:
                 list_element = valueToElement(
                     field.value_type, v, 'element', force)


### PR DESCRIPTION
in https://github.com/plone/plone.app.contentrules/pull/51 the test was getting inconsistent results for a set schema so just making sure supermodel serialises the same each time. It should sort the result for sets.