### PR TITLE
support zope.interface 5.x+ with deferred _v_attrs dict creation

### DIFF
--- a/news/33.feature
+++ b/news/33.feature
@@ -1,0 +1,2 @@
+zope.interface master, upcoming v5.0, initializes ``_v_attrs`` with ``None`` to save memory and creates the dict upon first usage.
+So we need to do so in order to support the new version.

--- a/plone/supermodel/utils.py
+++ b/plone/supermodel/utils.py
@@ -298,7 +298,7 @@ def syncSchema(source, dest, overwrite=False, sync_bases=False):
         for name in to_delete:
             # delattr(dest, name)
             del dest._InterfaceClass__attrs[name]
-            if hasattr(dest, '_v_attrs'):
+            if hasattr(dest, '_v_attrs') and dest._v_attrs is not None:
                 del dest._v_attrs[name]
 
     # Add fields that are in source, but not in dest
@@ -317,6 +317,8 @@ def syncSchema(source, dest, overwrite=False, sync_bases=False):
             # setattr(dest, name, clone)
             dest._InterfaceClass__attrs[name] = clone
             if hasattr(dest, '_v_attrs'):
+                if dest._v_attrs is None:
+                    dest._v_attrs = {}
                 dest._v_attrs[name] = clone
 
     # Copy tagged values


### PR DESCRIPTION
Current `zope.interface` `master`, upcoming v5.0, create initializes `_v_attrs` with `None` to save memory and creates the `dict` upon first usage. So we need to do so in order to support the new version.