### PR TITLE
Make finalizeSchema more robust by not handling behavior schema classes.

### DIFF
--- a/news/186.feature
+++ b/news/186.feature
@@ -1,0 +1,3 @@
+Make finalizeSchema more robust by not handling behavior schema classes.
+Backported from version 2.0.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import os
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-version = '1.6.6.dev0'
+version = '1.7.0.dev0'
 
 long_description = (
     read('README.rst') + '\n' +


### PR DESCRIPTION
This is for the branch used in Plone 5.2.
Backported from version 2.0, specifically PR #27 which was needed to get the dexterity site root working.  I already [commented there two years ago](https://github.com/plone/plone.supermodel/pull/27#pullrequestreview-732706075) that I wondered if this would be safe for 5.2 as well.

This fixes test failures on Plone 5.2 Python 3 when used together with https://github.com/plone/plone.dexterity/pull/189, which is a backport of a memory leak fix. Failures are like this:

```
File "/home/jenkins/.buildout/eggs/cp38/plone.autoform-1.9.1-py3.8.egg/plone/autoform/tests/../autoform.rst", line 50, in autoform.rst
Failed example:
    xmlconfig.xmlconfig(StringIO(configuration))
Exception raised:
    Traceback (most recent call last):
      File "/srv/python3.8/lib/python3.8/doctest.py", line 1336, in __run
        exec(compile(example.source, filename, "single",
      File "<doctest autoform.rst[11]>", line 1, in <module>
        xmlconfig.xmlconfig(StringIO(configuration))
      File "/home/jenkins/.buildout/eggs/cp38/zope.configuration-4.4.1-py3.8.egg/zope/configuration/xmlconfig.py", line 732, in xmlconfig
        context.execute_actions(testing=testing)
      File "/home/jenkins/.buildout/eggs/cp38/zope.configuration-4.4.1-py3.8.egg/zope/configuration/config.py", line 799, in execute_actions
        reraise(
      File "/home/jenkins/.buildout/eggs/cp38/zope.configuration-4.4.1-py3.8.egg/zope/configuration/_compat.py", line 31, in reraise
        raise value.with_traceback(tb)
      File "/home/jenkins/.buildout/eggs/cp38/zope.configuration-4.4.1-py3.8.egg/zope/configuration/config.py", line 791, in execute_actions
        callable(*args, **kw)
      File "/home/jenkins/.buildout/eggs/cp38/plone.supermodel-1.6.5-py3.8.egg/plone/supermodel/model.py", line 116, in finalizeSchemas
        for schema in sorted(schemas):
    zope.configuration.config.ConfigurationExecutionError: File "/home/jenkins/.buildout/eggs/cp38/plone.supermodel-1.6.5-py3.8.egg/plone/supermodel/configure.zcml", line 9.4-12.10
          <zcml:customAction
              handler=".model.finalizeSchemas"
              order="9999999"
              />

        TypeError: '<' not supported between instances of 'Provides' and 'InterfaceClass'
```

The test failures are mostly in `plone.autoform` and in `plone.app.registry`, but strangely you do not get the error when you run only the tests for one of those packages. You really need to run the entire Plone test suite (`bin/test` in coredev, without options).  So there is likely some test leakage.  See [all failures on Jenkins](https://jenkins.plone.org/job/pull-request-5.2-3.8/523/testReport/).

Python 2 does not have this problem: sorting on Python 3 is handled differently. On Python 2:

```
>>> from zope.interface.declarations import Implements, Provides
>>> sorted([Implements(), Provides(object)])
[classImplements(?), directlyProvides(object)]
```

On Python 3:

```
>>> from zope.interface.declarations import Implements, Provides
>>> sorted([Implements(), Provides(object)])
Traceback (most recent call last):
  File "<console>", line 1, in <module>
TypeError: '<' not supported between instances of 'Provides' and 'Implements'
```